### PR TITLE
Chore: fix version number typo in api definition

### DIFF
--- a/code/API_definitions/home_devices_qod.yaml
+++ b/code/API_definitions/home_devices_qod.yaml
@@ -37,7 +37,7 @@ servers:
         default: api.example.com
         description: Host that serves the API
       basePath:
-        default: /home-devices-qod/v1
+        default: /home-devices-qod/v0
         description: API URL prefix for all API paths
 paths:
   /dscp:

--- a/code/API_definitions/home_devices_qod.yaml
+++ b/code/API_definitions/home_devices_qod.yaml
@@ -29,7 +29,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 1.0.0
+  version: 0.1.0
 servers:
   - url: https://{host}{basePath}
     variables:


### PR DESCRIPTION
Fix version number typo in api definition YAML file as it should be v0.1.0 (representing the first API proposal) and not yet v1.0.0.