### PR TITLE
jpengar/rfc4594-based-change-for-issue-23-v0.2.0

### DIFF
--- a/code/API_definitions/home_devices_qod.yaml
+++ b/code/API_definitions/home_devices_qod.yaml
@@ -2,25 +2,26 @@ openapi: 3.0.3
 info:
   title: Home Devices QoD - DRAFT VERSION
   description: |-
-    Service Enabling Network Function API for *QoS-on-demand* (QoD) control applied to devices connected to the user home network. API clients can request to change on demand DSCP value for the IP traffic corresponding to a specific user home device.
+    Service Enabling Network Function API for *QoS-on-demand* (QoD) control applied to devices connected to the user home network. API clients can request to change, ondemand, the desired QoS behaviour for the IP traffic corresponding to a specific user home device. The QoS behaviour is determined by the Service Class provided by the API Client, which is mapped to a DSCP value according to [RFC4594](https://datatracker.ietf.org/doc/html/rfc4594) guidelines.
 
     # Relevant Definitions and concepts
 
-    - **Home Devices**: user devices connected to the user home network.
+    - **Home Devices**: User devices connected to the user home network.
     - **NaaS**: *Network-as-a-Service* model where Telco Network resources are exposed to third parties through APIs. In this particular API, QoD operations for home devices are exposed following this model.
-    - **DSCP**: *Differentiated Services (DiffServ) Code Point*. DiffServ is a simple and scalable mechanism for classifying and managing network traffic and providing quality of service (QoS) on IP networks. The DSCP value will be used to classify the traffic of the target home device in order to be treated accordingly.
+    - **Service Class**: A statement of the required QoS characteristics of a traffic aggregate. Conceptually, a service class refers to applications with similar characteristics and performance requirements.
+    - **DSCP**: *Differentiated Services (DiffServ) Code Point*. DiffServ is a simple and scalable mechanism for classifying and managing network traffic and providing quality of service (QoS) on IP networks. The DSCP value will be used to classify the traffic of the target home device in order to be treated accordingly. 
 
     # API Functionality
 
-    This API allows to third party clients to set on demand the DSCP value associated to the traffic of the device connected to the user home network matching the input criteria provided. Device traffic will be classified and treated accordingly.
+    This API allows to third party clients to set, on demand, the desired QoS behaviour (service class) associated to the traffic of the device connected to the user home network that matches the input criteria provided. The device traffic is classified (by DSCP) and treated accordingly.
      
-    - **NOTE: This API allows to apply QoS treatment for a target user device only within user Home Network** 
+    - **NOTE: This API allows QoS treatment to be applied to a target user device only within the user Home Network (i.e. between the device and the home router)**.
 
     # Resources and Operations overview
 
     The API provides a single endpoint:
      
-    - An endpoint to set the desired DSCP value for the traffic corresponding to the user device matching the input criteria.
+    - An endpoint to set the desired QoS behaviour for the traffic corresponding to the user home device matching the input criteria.
   termsOfService: http://example.com/terms/
   contact:
     name: API Support
@@ -40,18 +41,18 @@ servers:
         default: /home-devices-qod/v0
         description: API URL prefix for all API paths
 paths:
-  /dscp:
+  /qos:
     put:
-      summary: Set the desired DSCP value for a user home device
+      summary: Set the desired QoS behaviour for a user home device
       description: |-
-        Set the desired DSCP value for the traffic corresponding to the user home device matching the input criteria. **Setting DSCP value to CS0 restores default traffic treatment for the target home device.**
+        Set the desired QoS behaviour for the traffic corresponding to the user home device matching the input criteria. **QoS behaviour is determined by the service class provided by the API Client. Setting `Standard` service class restores default traffic treatment for the target home device.**
         
         - The operation is executed for the user whose `sub` is in the access token used to call this endpoint, and for the home network also deducted from the information included in the access token.
         - The target user device is identified by the internal IP address of that device in the home network.
         - In case there is no device matching the input criteria, the operation returns a 404 error.
       tags:
         - Home Devices QoD
-      operationId: setDscp
+      operationId: setQos
       parameters:
         - in: header
           name: x-correlator
@@ -63,7 +64,10 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DscpUpdate'
+              $ref: '#/components/schemas/QosOnDemandUpdate'
+            example: 
+              service_class: real_time_interactive
+              ip_address: 192.168.1.27
         required: true
       responses:
         '204':
@@ -72,59 +76,61 @@ paths:
               description: Correlation id for the different services
               schema:
                 type: string
-          description: New DSCP value passed all validations and was applied
+          description: Requested QoS passed all validations and was applied
         '400':
           $ref: '#/components/responses/InvalidArgument'
         '401':
           $ref: '#/components/responses/Unauthenticated'
         '403':
-          $ref: '#/components/responses/SetDscpPermissionDenied'
+          $ref: '#/components/responses/setQosPermissionDenied'
         '404':
-          $ref: '#/components/responses/SetDscpNotFound'
+          $ref: '#/components/responses/setQosNotFound'
         '409':
-          $ref: '#/components/responses/SetDscpConflict'
+          $ref: '#/components/responses/setQosConflict'
         '500':
           $ref: '#/components/responses/Internal'
         '503':
-          $ref: '#/components/responses/SetDscpServiceUnavailable'
+          $ref: '#/components/responses/setQosServiceUnavailable'
         '504':
           $ref: '#/components/responses/Timeout'
 components:
   schemas:
-    DscpUpdate:
+    QosOnDemandUpdate:
       type: object
-      description: Payload to change the prioritization status of a device.
+      description: Payload to change the QoS behaviour associated to a device.
       required:
-        - dscp
+        - service_class
         - ip_address
       properties:
-        dscp:
+        service_class:
           type: string
-          description: DSCP information for QoS
+          description: |-
+            The name of the service class requested by the API client. It is associated with QoS behaviours optimised for a particular application type. Each service class is mapped to a DSCP value according to [RFC4594](https://datatracker.ietf.org/doc/html/rfc4594) guidelines. The DSCP value is used to classify the target home device's traffic so that it can be treated accordingly (i.e. to meet its QoS needs).
+            
+            The following service classes are supported:
+
+            | Service Class Name    | DSCP Name | DSCP value (decimal) | DCSP value (binary) | Application Examples                          |
+            |-----------------------|-----------|----------------------|---------------------|-----------------------------------------------|
+            | Real-Time Interactive |    CS4    |          32          |        100000       | Video conferencing and Interactive gaming     |
+            | Multimedia Streaming  |    AF31   |          26          |        011010       | Streaming video and audio on demand           |
+            | Broadcast Video       |    CS3    |          24          |        011000       | Broadcast TV & live events                    |
+            | Low-Latency Data      |    AF21   |          18          |        010010       | Client/server transactions Web-based ordering |
+            | High-Throughput Data  |    AF11   |          10          |        001010       | Store and forward applications                |
+            | Low-Priority Data     |    CS1    |           8          |        001000       | Any flow that has  no BW assurance            |
+            | Standard              |  DF(CS0)  |           0          |        000000       | Undifferentiated applications                 |
+            | MAX_ALLOWED           |     *     |           *          |          *          | *                                             |
+            
+            (*) There is an additional special service class name defined as `max_allowed`. This is a placeholder for the maximum DSCP value allowed by the Operator (e.g. CS4).
           enum:
-            - CS0
-            - CS1
-            - AF11
-            - AF12
-            - AF13
-            - CS2
-            - AF21
-            - AF22
-            - AF23
-            - CS3
-            - AF31
-            - AF32
-            - AF33
-            - CS4
-            - AF41
-            - AF42
-            - AF43
-            - CS5
-            - EF
-            - CS6
-            - CS7
-            - MAX_ALLOWED
-          example: CS0
+            - real_time_interactive
+            - multimedia_streaming           
+            - broadcast_video
+            - low_latency_data
+            - high_throughput_data
+            - standard
+            - low_priority_data
+            - max_allowed
+          example: real_time_interactive 
         ip_address:
           type: string
           format: ipv4
@@ -178,7 +184,7 @@ components:
                 - HOME_DEVICES_QOD.NOT_SUPPORTED_REQUIRED_INTERFACE
                 - HOME_DEVICES_QOD.QOS_ALREADY_SET_TO_DEFAULT
               default: CONFLICT
-              description: Device can't be prioritized because a precondition does not hold
+              description: Requested QoS can't be applied to the target device because a precondition does not hold
         - $ref: '#/components/schemas/ModelError'
     NoDeviceMatch:
       allOf:
@@ -265,7 +271,7 @@ components:
                 status: "401"
                 code: UNAUTHENTICATED
                 message: Request not authenticated due to missing, invalid, or expired credentials
-    SetDscpPermissionDenied:
+    setQosPermissionDenied:
       description: |-
         Client does not have sufficient permission.
         In addition to regular PERMISSION_DENIED scenario another scenario may exist:
@@ -285,7 +291,7 @@ components:
                 status: "403"
                 code: HOME_DEVICES_QOD.INVALID_TOKEN_CONTEXT
                 message: User home network cannot be deducted from access token context
-    SetDscpNotFound:
+    setQosNotFound:
       description: |-
         Resource Not Found.
         In addition to regular scenario of NOT_FOUND, another scenario may exist.
@@ -305,18 +311,18 @@ components:
                 status: "404"
                 code: HOME_DEVICES_QOD.NO_DEVICE_MATCH
                 message: No connected device found for the input criteria provided
-    SetDscpConflict:
+    setQosConflict:
       description: |-
-        DSCP value can't be set. 
+        Requested QoS can't be set. 
         
         In addition to regular CONFLICT scenario to handle conflict with the current state of the target resource, another scenarios may exist:
-         - HOME_DEVICES_QOD.TOO_MANY_DEVICES: Exceeded the maximum quantity of devices with non-default DSCP value.
+         - HOME_DEVICES_QOD.TOO_MANY_DEVICES: Exceeded the maximum quantity of devices with non-default QoS behaviour.
          - HOME_DEVICES_QOD.RSSI_BELOW_THRESHOLD: RSSI from device is below allowed threshold.
-         - HOME_DEVICES_QOD.QOS_TOO_HIGH: DSCP requested is above the maximum QoS permitted.
+         - HOME_DEVICES_QOD.QOS_TOO_HIGH: Requested QoS is higher than the maximum QoS allowed.
          - HOME_DEVICES_QOD.OCCUPANCY_ABOVE_THRESHOLD: The occupancy is above the allowed threshold.
          - HOME_DEVICES_QOD.NOT_CONNECTED_TO_REQUIRED_INTERFACE: Device is not connected to the required interface (e.g. WiFi 5GHz interface).
          - HOME_DEVICES_QOD.NOT_SUPPORTED_REQUIRED_INTERFACE: Device does not support required interface (e.g. WiFi 5GHz interface).
-         - HOME_DEVICES_QOD.QOS_ALREADY_SET_TO_DEFAULT: Device DSCP value is already set to default value.
+         - HOME_DEVICES_QOD.QOS_ALREADY_SET_TO_DEFAULT: Device QoS is already set to default value.
       headers:
         x-correlator:
           description: Correlation id for the different services
@@ -331,7 +337,7 @@ components:
               value:
                 status: "409"
                 code: HOME_DEVICES_QOD.TOO_MANY_DEVICES
-                message: Exceeded the maximum quantity of devices with non-default DSCP value
+                message: Exceeded the maximum quantity of devices with non-default QoS behaviour
     Internal:
       description: Server error
       headers:
@@ -360,7 +366,7 @@ components:
                 status: "500"
                 code: INTERNAL
                 message: Server error
-    SetDscpServiceUnavailable:
+    setQosServiceUnavailable:
       description: |-
         Service unavailable. Typically the server is down.
         
@@ -408,14 +414,14 @@ components:
               value:
                 status: "504"
                 code: TIMEOUT
-                message: Request timeout exceeded. If it happens repeatedly, consider reducing the request complexity
+                message: Request timeout exceeded
   securitySchemes:
     three_legged:
       type: openIdConnect
       openIdConnectUrl: https://example.com/.well-known/openid-configuration
 security:
   - three_legged:
-    - home-devices-qod-dscp-write
+    - home-devices-qod-qos-write
 tags:
   - name: Home Devices QoD
     description: QoD control operations for home devices


### PR DESCRIPTION
PR to address the issue https://github.com/camaraproject/HomeDevicesQoD/issues/23

[RFC4594](https://datatracker.ietf.org/doc/html/rfc4594)-based Proposal to provide a service class as the way to to set the desired QoS behaviour for the traffic corresponding to the user home device matching the input criteria. DSCP value would be not directly provided.

The API proposal would be more dev-friendly and it avoids network specific concepts and acronyms. This is actually aligned with Commonalities issue [#108](https://github.com/camaraproject/WorkingGroups/issues/108) and PR [#120](https://github.com/camaraproject/WorkingGroups/pull/120).