### PR TITLE
Add CHANGELOG.md for release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog QualityOnDemand
+
+## Table of Contents
+
+
+- [v0.1.0 - Initial contribution](#v010---initial-contribution)
+
+**Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until it has been released. For example, changes may be reverted before a release is published. For the best results, use the latest published release.**
+
+# v0.1.0 - Initial contribution
+
+**Initial contribution of the API definition for *QoS-on-demand* (QoD) control applied to devices connected to the user home network**, including initial API documentation.
+- API [definition](https://github.com/camaraproject/HomeDevicesQoD/tree/release-0.1.0/code/API_definitions)
+- API [documentation](https://github.com/camaraproject/HomeDevicesQoD/tree/release-0.1.0/documentation/API_documentation)
+
+## Please note 
+- This "release" is only tagged to document the history of the API as initial contribution
+- This is an alpha version, it should be considered as a draft.
+
+## What's Changed
+* Home Devices QoD api spec 0.1.0 contribution by @jpengar in https://github.com/camaraproject/HomeDevicesQoD/pull/12
+* Home Devices QoD api user stories doc 0.1.0 contribution by @jpengar in https://github.com/camaraproject/HomeDevicesQoD/pull/10 
+* Home Devices Qod api documentation 0.1.0 contribution by @jpengar in https://github.com/camaraproject/HomeDevicesQoD/pull/15
+
+### Added
+
+* Initial contribution
+  
+### Changed
+
+* N/A
+
+### Fixed
+
+* N/A
+
+### Removed
+
+* N/A
+
+## New Contributors
+* N/A
+
+**Full Changelog**: https://github.com/camaraproject/HomeDevicesQoD/commits/v0.1.0


### PR DESCRIPTION
Address issue https://github.com/camaraproject/HomeDevicesQoD/issues/27

>Adapt project to release/versioning guidelines agreed in Commonalities.
>https://github.com/camaraproject/WorkingGroups/pull/123
>The next steps are expected to be:
>- PR to merge v0.1.0 changelog into the main branch.
>- The merge commit from PR will be tagged as v0.1.0, and will get the v0.1.0 release branch.
>- Merge the dev-v0.2.0 branch into main, so that it contains the latest stable API definition state as agreed.