### PR TITLE
Align API spec format with the latest Commonalities agreements

### DIFF
--- a/code/API_definitions/home_devices_qod.yaml
+++ b/code/API_definitions/home_devices_qod.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.3
 info:
-  title: Home Devices QoD - DRAFT VERSION
+  title: Home Devices QoD
   description: |-
-    Service Enabling Network Function API for *QoS-on-demand* (QoD) control applied to devices connected to the user home network. API clients can request to change, ondemand, the desired QoS behaviour for the IP traffic corresponding to a specific user home device. The QoS behaviour is determined by the Service Class provided by the API Client, which is mapped to a DSCP value according to [RFC4594](https://datatracker.ietf.org/doc/html/rfc4594) guidelines.
+    Service Enabling Network Function API for *QoS-on-demand* (QoD) control applied to devices connected to the user home network. API clients can request to change, on demand, the desired QoS behaviour for the IP traffic corresponding to a specific user home device. The QoS behaviour is determined by the Service Class provided by the API Client, which is mapped to a DSCP value according to [RFC4594](https://datatracker.ietf.org/doc/html/rfc4594) guidelines.
 
     # Relevant Definitions and concepts
 
@@ -45,7 +45,7 @@ paths:
     put:
       summary: Set the desired QoS behaviour for a user home device
       description: |-
-        Set the desired QoS behaviour for the traffic corresponding to the user home device matching the input criteria. **QoS behaviour is determined by the service class provided by the API Client. Setting `Standard` service class restores default traffic treatment for the target home device.**
+        Set the desired QoS behaviour for the traffic corresponding to the user home device matching the input criteria. **QoS behaviour is determined by the service class provided by the API Client. Setting `standard` service class restores default traffic treatment for the target home device.**
         
         - The operation is executed for the user whose `sub` is in the access token used to call this endpoint, and for the home network also deducted from the information included in the access token.
         - The target user device is identified by the internal IP address of that device in the home network.
@@ -54,33 +54,26 @@ paths:
         - Home Devices QoD
       operationId: setQos
       parameters:
-        - in: header
-          name: x-correlator
-          required: false
-          description: Correlation id for the different services
-          schema:
-            type: string
+        - $ref: '#/components/parameters/x-correlator'
       requestBody:
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/QosOnDemandUpdate'
             example: 
-              service_class: real_time_interactive
-              ip_address: 192.168.1.27
+              serviceClass: real_time_interactive
+              ipAddress: 192.168.1.27
         required: true
       responses:
         '204':
           headers:
             x-correlator:
-              description: Correlation id for the different services
-              schema:
-                type: string
+              $ref: '#/components/headers/x-correlator'
           description: Requested QoS passed all validations and was applied
         '400':
-          $ref: '#/components/responses/InvalidArgument'
+          $ref: '#/components/responses/Error400InvalidArgument'
         '401':
-          $ref: '#/components/responses/Unauthenticated'
+          $ref: '#/components/responses/Error401Unauthenticated'
         '403':
           $ref: '#/components/responses/setQosPermissionDenied'
         '404':
@@ -88,21 +81,21 @@ paths:
         '409':
           $ref: '#/components/responses/setQosConflict'
         '500':
-          $ref: '#/components/responses/Internal'
+          $ref: '#/components/responses/Error500Internal'
         '503':
           $ref: '#/components/responses/setQosServiceUnavailable'
         '504':
-          $ref: '#/components/responses/Timeout'
+          $ref: '#/components/responses/Error504Timeout'
 components:
   schemas:
     QosOnDemandUpdate:
       type: object
       description: Payload to change the QoS behaviour associated to a device.
       required:
-        - service_class
-        - ip_address
+        - serviceClass
+        - ipAddress
       properties:
-        service_class:
+        serviceClass:
           type: string
           description: |-
             The name of the service class requested by the API client. It is associated with QoS behaviours optimised for a particular application type. Each service class is mapped to a DSCP value according to [RFC4594](https://datatracker.ietf.org/doc/html/rfc4594) guidelines. The DSCP value is used to classify the target home device's traffic so that it can be treated accordingly (i.e. to meet its QoS needs).
@@ -118,157 +111,66 @@ components:
             | High-Throughput Data  |    AF11   |          10          |        001010       | Store and forward applications                |
             | Low-Priority Data     |    CS1    |           8          |        001000       | Any flow that has  no BW assurance            |
             | Standard              |  DF(CS0)  |           0          |        000000       | Undifferentiated applications                 |
-            | MAX_ALLOWED           |     *     |           *          |          *          | *                                             |
-            
-            (*) There is an additional special service class name defined as `max_allowed`. This is a placeholder for the maximum DSCP value allowed by the Operator (e.g. CS4).
           enum:
             - real_time_interactive
             - multimedia_streaming           
             - broadcast_video
             - low_latency_data
             - high_throughput_data
-            - standard
             - low_priority_data
-            - max_allowed
+            - standard
           example: real_time_interactive 
-        ip_address:
+        ipAddress:
           type: string
           format: ipv4
           pattern: '^([01]?\d\d?|2[0-4]\d|25[0-5])(?:\.(?:[01]?\d\d?|2[0-4]\d|25[0-5])){3}?$'
           description: Internal IP address of the connected device in the LAN.
           example: 192.168.1.27
-    ModelError:
+    ErrorInfo:
       type: object
       required:
         - status
+        - code
         - message
       properties:
         status:
+          type: integer
+          description: HTTP status code returned along with this error response
+        code:
           type: string
-          pattern: '^[1-5][0-9][0-9]$'
-          description: HTTP response status code
+          description: A code value within the allowed set of values for this error
         message:
           type: string
-          description: A human readable description of what the event represent
-    RouterActionsUnavailable:
-      allOf:
-        - type: object
-          required:
-            - code
-          properties:
-            code:
-              type: string
-              enum:
-                - UNAVAILABLE
-                - HOME_DEVICES_QOD.ROUTER_OFFLINE
-              default: UNAVAILABLE
-              description: |-
-                  Service unavailable. Typically the server is down.
-                  Router is not online. Try it later.
-        - $ref: '#/components/schemas/ModelError'
-    DscpConflict:
-      allOf:
-        - type: object
-          required:
-            - code
-          properties:
-            code:
-              type: string
-              enum:
-                - CONFLICT
-                - HOME_DEVICES_QOD.TOO_MANY_DEVICES
-                - HOME_DEVICES_QOD.RSSI_BELOW_THRESHOLD
-                - HOME_DEVICES_QOD.QOS_TOO_HIGH
-                - HOME_DEVICES_QOD.OCCUPANCY_ABOVE_THRESHOLD
-                - HOME_DEVICES_QOD.NOT_CONNECTED_TO_REQUIRED_INTERFACE
-                - HOME_DEVICES_QOD.NOT_SUPPORTED_REQUIRED_INTERFACE
-                - HOME_DEVICES_QOD.QOS_ALREADY_SET_TO_DEFAULT
-              default: CONFLICT
-              description: Requested QoS can't be applied to the target device because a precondition does not hold
-        - $ref: '#/components/schemas/ModelError'
-    NoDeviceMatch:
-      allOf:
-        - type: object
-          required:
-            - code
-          properties:
-            code:
-              type: string
-              enum:
-                - NOT_FOUND
-                - HOME_DEVICES_QOD.NO_DEVICE_MATCH
-              default: NOT_FOUND
-              description: There is no device matching the input criteria
-        - $ref: '#/components/schemas/ModelError'
-    InvalidTokenContext:
-      allOf:
-        - type: object
-          required:
-            - code
-          properties:
-            code:
-              type: string
-              enum:
-                - PERMISSION_DENIED
-                - HOME_DEVICES_QOD.INVALID_TOKEN_CONTEXT
-              default: PERMISSION_DENIED
-              description: User home network cannot be deducted from access token context
-        - $ref: '#/components/schemas/ModelError'
+          description: A human readable description of what the event represents
   responses:
-    InvalidArgument:
+    Error400InvalidArgument:
       description: Problem with the client request
       headers:
         x-correlator:
-          description: Correlation id for the different services
-          schema:
-            type: string
+          $ref: '#/components/headers/x-correlator'
       content:
         application/json:
           schema:
-            allOf:
-              - type: object
-                required:
-                  - code
-                properties:
-                  code:
-                    type: string
-                    enum:
-                      - INVALID_ARGUMENT
-                    default: INVALID_ARGUMENT
-                    description: Client specified an invalid argument, request body or query param.
-              - $ref: '#/components/schemas/ModelError'
+            $ref: "#/components/schemas/ErrorInfo"
           examples:
-            response:
+            InvalidArgument:
               value:
-                status: "400"
+                status: 400
                 code: INVALID_ARGUMENT
                 message: Client specified an invalid argument, request body or query param
-    Unauthenticated:
+    Error401Unauthenticated:
       description: Authentication problem with the client request
       headers:
         x-correlator:
-          description: Correlation id for the different services
-          schema:
-            type: string
+          $ref: '#/components/headers/x-correlator'
       content:
         application/json:
           schema:
-            allOf:
-              - type: object
-                required:
-                  - code
-                properties:
-                  code:
-                    type: string
-                    enum:
-                      - UNAUTHENTICATED
-                    default: UNAUTHENTICATED
-                    description: Request not authenticated due to missing, invalid, or expired credentials.
-              - $ref: '#/components/schemas/ModelError'
+            $ref: "#/components/schemas/ErrorInfo"
           examples:
-            response:
+            Unauthenticated:
               value:
-                status: "401"
+                status: 401
                 code: UNAUTHENTICATED
                 message: Request not authenticated due to missing, invalid, or expired credentials
     setQosPermissionDenied:
@@ -278,17 +180,20 @@ components:
           - User home network cannot be deducted from access token context.("code": "HOME_DEVICES_QOD.INVALID_TOKEN_CONTEXT","message": "User home network cannot be deducted from access token context.").
       headers:
         x-correlator:
-          description: Correlation id for the different services
-          schema:
-            type: string
+          $ref: '#/components/headers/x-correlator'
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/InvalidTokenContext'
+            $ref: "#/components/schemas/ErrorInfo"
           examples:
-            response:
+            PermissionDenied:
               value:
-                status: "403"
+                status: 403
+                code: PERMISSION_DENIED
+                message: Client does not have sufficient permissions to perform this action
+            InvalidTokenContext:
+              value:
+                status: 403
                 code: HOME_DEVICES_QOD.INVALID_TOKEN_CONTEXT
                 message: User home network cannot be deducted from access token context
     setQosNotFound:
@@ -298,17 +203,20 @@ components:
          - There is no device matching the input criteria. ("code": "HOME_DEVICES_QOD.NO_DEVICE_MATCH","message": "No connected device found for the input criteria provided.").
       headers:
         x-correlator:
-          description: Correlation id for the different services
-          schema:
-            type: string
+          $ref: '#/components/headers/x-correlator'
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/NoDeviceMatch'
+            $ref: "#/components/schemas/ErrorInfo"
           examples:
-            response:
+            NotFound:
               value:
-                status: "404"
+                status: 404
+                code: NOT_FOUND
+                message: The specified resource is not found
+            NoDeviceMatch:
+              value:
+                status: 404
                 code: HOME_DEVICES_QOD.NO_DEVICE_MATCH
                 message: No connected device found for the input criteria provided
     setQosConflict:
@@ -325,45 +233,65 @@ components:
          - HOME_DEVICES_QOD.QOS_ALREADY_SET_TO_DEFAULT: Device QoS is already set to default value.
       headers:
         x-correlator:
-          description: Correlation id for the different services
-          schema:
-            type: string
+          $ref: '#/components/headers/x-correlator'
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/DscpConflict'
+            $ref: "#/components/schemas/ErrorInfo"
           examples:
-            response:
+            Conflict:
               value:
-                status: "409"
+                status: 409
+                code: CONFLICT
+                message: Conflict with the current state of the target resource
+            TooManyDevices:
+              value:
+                status: 409
                 code: HOME_DEVICES_QOD.TOO_MANY_DEVICES
                 message: Exceeded the maximum quantity of devices with non-default QoS behaviour
-    Internal:
+            RssiBelowThreshold:
+              value:
+                status: 409
+                code: HOME_DEVICES_QOD.RSSI_BELOW_THRESHOLD
+                message: RSSI from device is below allowed threshold
+            QosTooHigh:
+              value:
+                status: 409
+                code: HOME_DEVICES_QOD.QOS_TOO_HIGH
+                message:  Requested QoS is higher than the maximum QoS allowed
+            OccupancyAboveThreshold:
+              value:
+                status: 409
+                code: HOME_DEVICES_QOD.OCCUPANCY_ABOVE_THRESHOLD
+                message: The occupancy is above the allowed threshold
+            NotConnectedToRequiredInterface:
+              value:
+                status: 409
+                code: HOME_DEVICES_QOD.NOT_CONNECTED_TO_REQUIRED_INTERFACE
+                message: Device is not connected to the required interface (e.g. WiFi 5GHz interface)
+            NotSupportedRequiredInterface:
+              value:
+                status: 409
+                code: HOME_DEVICES_QOD.NOT_SUPPORTED_REQUIRED_INTERFACE
+                message: Device does not support required interface (e.g. WiFi 5GHz interface)
+            QosAlreadySetToDefault:
+              value:
+                status: 409
+                code: HOME_DEVICES_QOD.QOS_ALREADY_SET_TO_DEFAULT
+                message: Device QoS is already set to default value
+    Error500Internal:
       description: Server error
       headers:
         x-correlator:
-          description: Correlation id for the different services
-          schema:
-            type: string
+          $ref: '#/components/headers/x-correlator'
       content:
         application/json:
           schema:
-            allOf:
-              - type: object
-                required:
-                  - code
-                properties:
-                  code:
-                    type: string
-                    enum:
-                      - INTERNAL
-                    default: INTERNAL
-                    description: Unknown server error.Typically a server bug.
-              - $ref: '#/components/schemas/ModelError'
+            $ref: "#/components/schemas/ErrorInfo"
           examples:
-            response:
+            Internal:
               value:
-                status: "500"
+                status: 500
                 code: INTERNAL
                 message: Server error
     setQosServiceUnavailable:
@@ -374,47 +302,49 @@ components:
          - The router is offline ("code": "HOME_DEVICES_QOD.ROUTER_OFFLINE","message": "Router is not online. Try it later.").
       headers:
         x-correlator:
-          description: Correlation id for the different services
-          schema:
-            type: string
+          $ref: '#/components/headers/x-correlator'
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/RouterActionsUnavailable'
+            $ref: "#/components/schemas/ErrorInfo"
           examples:
-            response:
+            Unavailable:
               value:
-                status: "503"
+                status: 503
+                code: UNAVAILABLE
+                message: Request timeout exceeded
+            RouterOffline:
+              value:
+                status: 503
                 code: HOME_DEVICES_QOD.ROUTER_OFFLINE
                 message: Router is not online. Try it later
-    Timeout:
+    Error504Timeout:
       description: Request time exceeded. If it happens repeatedly, consider reducing the request complexity
       headers:
         x-correlator:
-          description: Correlation id for the different services
-          schema:
-            type: string
+          $ref: '#/components/headers/x-correlator'
       content:
         application/json:
           schema:
-            allOf:
-              - type: object
-                required:
-                  - code
-                properties:
-                  code:
-                    type: string
-                    enum:
-                      - TIMEOUT
-                    default: TIMEOUT
-                    description: Request timeout exceeded
-              - $ref: '#/components/schemas/ModelError'
+            $ref: "#/components/schemas/ErrorInfo"
           examples:
-            response:
+            Timeout:
               value:
-                status: "504"
+                status: 504
                 code: TIMEOUT
                 message: Request timeout exceeded
+  parameters:
+    x-correlator:
+      name: x-correlator
+      in: header
+      description: Correlation id for the different services
+      schema:
+        type: string
+  headers:
+    x-correlator:
+      description: Correlation id for the different services
+      schema:
+        type: string
   securitySchemes:
     three_legged:
       type: openIdConnect


### PR DESCRIPTION
Address issue https://github.com/camaraproject/HomeDevicesQoD/issues/33

>Align API spec format with the latest Commonalities agreements:
>
>- Commonalities - adjust the error `status` field, which will eventually be an integer (not a patterned string): PR [#145](https://github.com/camaraproject/WorkingGroups/pull/145).
>- Commonalities - adjust the schema references in the errors responses and apply the agreed solution: Issue [#151](https://github.com/camaraproject/WorkingGroups/issues/151) & PR [#162](https://github.com/camaraproject/WorkingGroups/pull/162). 
>- Commonalities - change the format of the API fields to lowerCamelCase: Issue [#157](https://github.com/camaraproject/WorkingGroups/issues/157), Discussion [#169](https://github.com/camaraproject/WorkingGroups/discussions/169) & PR [#171](https://github.com/camaraproject/WorkingGroups/pull/171).

In addition, this PR includes:
- Some minor optimisations of non-functional definitions in the API spec.
- Removal of `max_allowed` missed as part of [RFC4594](https://datatracker.ietf.org/doc/html/rfc4594) related changes made as a result of issue [#23](https://github.com/camaraproject/HomeDevicesQoD/issues/23).