### PR TITLE
Fernando replaces Mona as Telefónica codeowner and maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
 
-* @jpengar @monamok
+* @jpengar @fernandopradocabrillo

--- a/MAINTAINERS.MD
+++ b/MAINTAINERS.MD
@@ -4,5 +4,5 @@
 | Orange | Ludovic Robert |
 | Scenera | Andrew Wajs|
 | Telefonica | Jesús Peña |
-| Telefónica | Mona Mokhber |
+| Telefónica | Fernando Prado |
 | Deutsche Telekom | Rafal Artych |


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* subproject management


#### What this PR does / why we need it:
Mona (@monamok) will be replaced in Telefónica by Fernando (@fernandopradocabrillo)


#### Which issue(s) this PR fixes:

N/A

#### Special notes for reviewers:



#### Changelog input

N/A

#### Additional documentation 

N/A
